### PR TITLE
fix markdown rendering of headings with IDs

### DIFF
--- a/heading.go
+++ b/heading.go
@@ -40,7 +40,10 @@ func (b *Heading) printMarkdown(buf *bytes.Buffer, s mdState) {
 	s.prefix = ""
 	b.Text.printMarkdown(buf, s)
 	if b.ID != "" {
-		fmt.Fprintf(buf, " {#%s}", b.ID)
+    	// A heading text is a block, so it ends in a newline. Move the newline
+    	// after the ID.
+    	buf.Truncate(buf.Len()-1)
+		fmt.Fprintf(buf, " {#%s}\n", b.ID)
 	}
 }
 

--- a/md_test.go
+++ b/md_test.go
@@ -208,3 +208,14 @@ func TestToMarkdown(t *testing.T) {
 		})
 	}
 }
+
+func TestHeadingIDToMarkdown(t *testing.T) {
+	p := Parser{HeadingIDs: true}
+	text := `# H {#id}`
+	doc := p.Parse(text)
+	got := ToMarkdown(doc)
+	want := text + "\n"
+	if got != want{
+		t.Errorf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Move the newline after the heading text to after the ID.