### PR TITLE
Render reference links in Markdown

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -808,7 +808,7 @@ func (p *parseState) parseLinkClose(s string, i int, open *openPlain) (*Link, in
 				break
 			}
 			if link, ok := p.links[normalizeLabel(label)]; ok {
-				return &Link{URL: link.URL, Title: link.Title, corner: link.corner}, i, true
+				return &Link{URL: link.URL, Title: link.Title, corner: link.corner, label: label}, i, true
 			}
 			// Note: Could break here, but CommonMark dingus does not
 			// fall back to trying Text for [Text][Label] when Label is unknown.

--- a/inline.go
+++ b/inline.go
@@ -808,7 +808,7 @@ func (p *parseState) parseLinkClose(s string, i int, open *openPlain) (*Link, in
 				break
 			}
 			if link, ok := p.links[normalizeLabel(label)]; ok {
-				return &Link{URL: link.URL, Title: link.Title, corner: link.corner, label: label}, i, true
+				return &Link{URL: link.URL, Title: link.Title, corner: link.corner, label: label, kind: fullRef}, i, true
 			}
 			// Note: Could break here, but CommonMark dingus does not
 			// fall back to trying Text for [Text][Label] when Label is unknown.
@@ -819,12 +819,16 @@ func (p *parseState) parseLinkClose(s string, i int, open *openPlain) (*Link, in
 
 	// Collapsed or shortcut reference link: [Text][] or [Text].
 	end := i + 1
+	var refLink linkKind
 	if strings.HasPrefix(s[end:], "[]") {
+		refLink = collapsedRef
 		end += 2
+	} else {
+		refLink = shortcutRef
 	}
 
 	if link, ok := p.links[normalizeLabel(s[open.i:i])]; ok {
-		return &Link{URL: link.URL, Title: link.Title, corner: link.corner}, end, true
+		return &Link{URL: link.URL, Title: link.Title, corner: link.corner, kind: refLink}, end, true
 	}
 	return nil, 0, false
 }

--- a/link.go
+++ b/link.go
@@ -87,7 +87,7 @@ func parseLinkRefDef(p buildState, s string) (int, bool) {
 
 	label = normalizeLabel(label)
 	if p.link(label) == nil {
-		p.defineLink(label, &Link{URL: dest, Title: title, TitleChar: titleChar, corner: corner})
+		p.defineLink(label, &Link{URL: dest, Title: title, TitleChar: titleChar, corner: corner, label: label})
 	}
 	return i, true
 }
@@ -400,6 +400,7 @@ type Link struct {
 	Title     string
 	TitleChar byte // ', " or )
 	corner    bool
+	label     string
 }
 
 func (*Link) Inline() {}
@@ -425,10 +426,16 @@ func (x *Link) printRemainingMarkdown(buf *bytes.Buffer) {
 	for _, c := range x.Inner {
 		c.printMarkdown(buf)
 	}
-	buf.WriteString("](")
-	buf.WriteString(x.URL)
-	printLinkTitleMarkdown(buf, x.Title, x.TitleChar)
-	buf.WriteByte(')')
+	if x.label != "" {
+		buf.WriteString("][")
+		buf.WriteString(x.label)
+		buf.WriteByte(']')
+	} else {
+		buf.WriteString("](")
+		buf.WriteString(x.URL)
+		printLinkTitleMarkdown(buf, x.Title, x.TitleChar)
+		buf.WriteByte(')')
+	}
 }
 
 func printLinkTitleMarkdown(buf *bytes.Buffer, title string, titleChar byte) {
@@ -455,6 +462,7 @@ type Image struct {
 	Title     string
 	TitleChar byte
 	corner    bool
+	label     string
 }
 
 func (*Image) Inline() {}

--- a/link.go
+++ b/link.go
@@ -87,7 +87,7 @@ func parseLinkRefDef(p buildState, s string) (int, bool) {
 
 	label = normalizeLabel(label)
 	if p.link(label) == nil {
-		p.defineLink(label, &Link{URL: dest, Title: title, TitleChar: titleChar, corner: corner, label: label})
+		p.defineLink(label, &Link{URL: dest, Title: title, TitleChar: titleChar, corner: corner})
 	}
 	return i, true
 }

--- a/testdata/linkrefs_to_markdown.txt
+++ b/testdata/linkrefs_to_markdown.txt
@@ -39,6 +39,13 @@ A document.
 [r3]: u3 'title3'
 -- full reference link --
 [First][foo]
-[Second](u2)
+
+[foo]: u1
+-- collapsed reference link --
+[foo][]
+
+[foo]: u1
+-- shortcut reference link --
+[foo]
 
 [foo]: u1

--- a/testdata/linkrefs_to_markdown.txt
+++ b/testdata/linkrefs_to_markdown.txt
@@ -7,16 +7,6 @@ A document.
 A document.
 
 [foo]: u
--- labels --
-[First][foo]
-[Second](u2)
-
-[foo]: u1
--- want --
-[First][foo]
-[Second](u2)
-
-[foo]: u1
 -- sorted --
 A document.
 
@@ -47,3 +37,8 @@ A document.
 [r1]: u1 (title1)
 [r2]: u2 "title2"
 [r3]: u3 'title3'
+-- full reference link --
+[First][foo]
+[Second](u2)
+
+[foo]: u1

--- a/testdata/linkrefs_to_markdown.txt
+++ b/testdata/linkrefs_to_markdown.txt
@@ -7,6 +7,16 @@ A document.
 A document.
 
 [foo]: u
+-- labels --
+[First][foo]
+[Second](u2)
+
+[foo]: u1
+-- want --
+[First][foo]
+[Second](u2)
+
+[foo]: u1
 -- sorted --
 A document.
 


### PR DESCRIPTION
Attempting to address #13: correctly render reference links ([full], [collapsed], [shortcut]) in Markdown.

Sorry for the churn (renaming) with #14.

[full]: https://spec.commonmark.org/0.31.2/#full-reference-link
[collapsed]: https://spec.commonmark.org/0.31.2/#collapsed-reference-link
[shortcut]: https://spec.commonmark.org/0.31.2/#shortcut-reference-link