### PR TITLE
markdown: emit Info in CodeBlock markdown

### DIFF
--- a/code.go
+++ b/code.go
@@ -85,7 +85,7 @@ func (b *CodeBlock) printMarkdown(buf *bytes.Buffer, s mdState) {
 			fmt.Fprintf(buf, "%s%s%s\n", pre, "    ", line)
 		}
 	} else {
-		fmt.Fprintf(buf, "%s%s\n", prefix1, b.Fence)
+		fmt.Fprintf(buf, "%s%s%s\n", prefix1, b.Fence, b.Info)
 		for _, line := range b.Text {
 			fmt.Fprintf(buf, "%s%s\n", s.prefix, line)
 		}

--- a/testdata/basic_to_markdown.txt
+++ b/testdata/basic_to_markdown.txt
@@ -116,6 +116,10 @@ tildes
 func f(int)
 ~~~~~
 done
+-- codeblock6 --
+```go
+func f(int)
+```
 -- htmlblock --
 Literally,
 <pre>


### PR DESCRIPTION
Emit the Info field of CodeBlock in the CodeBlock.printMardown function so 
that a round trip from markdown to markdown will preserve the language Info.